### PR TITLE
fix: Use a more unique plan filename to avoid collisions

### DIFF
--- a/.github/workflows/reusable-terraform-plan-apply.yml
+++ b/.github/workflows/reusable-terraform-plan-apply.yml
@@ -152,16 +152,17 @@ jobs:
           ref: ${{ inputs.git_ref }}
 
 
-      - name: Add output parameter for the checked out commit SHA
-        id: output-checkout-sha
+      - name: Add output parameter for the checked out commit SHA and workdir short SHA
+        id: output-hashes
         run: |
           echo "CHECKOUT_SHA=$(git log -1 '--format=format:%H')" >> "$GITHUB_OUTPUT"
+          echo "WORKDIR_SHORT_SHA=$(echo -n ${{ inputs.working_directory }} | sha1sum | cut -c 1-7)" >> "$GITHUB_OUTPUT"
 
 
       - name: Add output parameter for the Terraform execution plan filename
         id: output-plan-filename
         run: |
-          echo "PLAN_FILENAME=plan-${{ github.run_id }}_${{ steps.output-checkout-sha.outputs.CHECKOUT_SHA }}.tfplan" >> "$GITHUB_OUTPUT"
+          echo "PLAN_FILENAME=plan-${{ github.run_id }}_${{ steps.output-hashes.outputs.CHECKOUT_SHA }}_${{ steps.output-hashes.outputs.WORKDIR_SHORT_SHA }}.tfplan" >> "$GITHUB_OUTPUT"
 
 
       - name: Setup Terraform


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes a bug where the plan filename would be identical when running the workflow in a matrix based on changed dirs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here using the syntax: 'Closes #123' -->

See https://oslokommune.slack.com/archives/CV9EGL9UG/p1694593955484959

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Is this a breaking change?
<!--- Does the change require the user to change something on their side? -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation, and I have updated the documentation accordingly.

<!-- markdownlint-disable-file MD041 -->
