### PR TITLE
feat: Use a more unique concurrency group name

### DIFF
--- a/.github/workflows/reusable-terraform-plan-apply.yml
+++ b/.github/workflows/reusable-terraform-plan-apply.yml
@@ -72,7 +72,7 @@ env:
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
 
 concurrency:
-  group: "${{ inputs.environment }}"
+  group: "${{ inputs.environment }}-${{ inputs.working_directory }}"
 
 jobs:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Use a more unique concurrency group name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here using the syntax: 'Closes #123' -->

Closes #17.

See [bug report on Slack here](https://oslokommune.slack.com/archives/C058XSRLCGL/p1695300114907899).

If you're working on multiple stacks simultaneously through a workflow matrix strategy and using a single GitHub environment for all stacks, you might encounter the error `Canceling since a higher priority waiting request for 'prod' exists`. 

While this commit helps to avoid the error, it's not foolproof. A more robust solution could be to allow users to specify their own concurrency group in the calling workflow. This feature might be considered for future releases.