### PR TITLE
feat!: Add secrets input to workflow call

### DIFF
--- a/.github/workflows/reusable-terraform-plan-apply.yml
+++ b/.github/workflows/reusable-terraform-plan-apply.yml
@@ -6,6 +6,15 @@ permissions:
 on:
 
   workflow_call:
+    secrets:
+      AWS_ROLE_ARN:
+        required: true
+      GOLDEN_PATH_IAC_PRIVATE_DEPLOY_KEY:
+        required: true
+      AGE_PUBLIC_KEY:
+        required: true
+      AGE_SECRET_KEY:
+        required: true
     inputs:
       environment:
         description: >


### PR DESCRIPTION
In order to support running this reusable workflow from other organizations, secrets must be passed explicitly. It's not possible to use `inherit`.

> Workflows that call reusable workflows in the same [organization or enterprise](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow) _can_ use the `inherit` keyword to implicitly pass the secrets.

## Breaking change

This is a breaking change. You might encounter this error message if you don't change your caller workflows:

```
This job failed
Secret AWS_ROLE_ARN is required, but not provided while calling.
```

In caller workflows, you need to make this change:

```diff
-    uses: oslokommune/reusable-terraform-plan-apply/.github/workflows/reusable-terraform-plan-apply.yml@main
-    secrets: inherit
+    uses: oslokommune/reusable-terraform-plan-apply/.github/workflows/reusable-terraform-plan-apply.yml@main
+    secrets:
+      AGE_PUBLIC_KEY: ${{ secrets.AGE_PUBLIC_KEY }}
+      AGE_SECRET_KEY: ${{ secrets.AGE_SECRET_KEY }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      GOLDEN_PATH_IAC_PRIVATE_DEPLOY_KEY: ${{ secrets.GOLDEN_PATH_IAC_PRIVATE_DEPLOY_KEY }}
```

See [this Slack discussion for more information](https://oslokommune.slack.com/archives/CV9EGL9UG/p1721729235793729).