### PR TITLE
feat: Replace job to extract Terraform version with shell command step

### DIFF
--- a/.github/workflows/reusable-terraform-plan-apply.yml
+++ b/.github/workflows/reusable-terraform-plan-apply.yml
@@ -85,39 +85,9 @@ concurrency:
 
 jobs:
 
-  terraform-version:
-
-    name: Determine and output Terraform version
-
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    outputs:
-      max: ${{ steps.v.outputs.maxVersion }}
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          ref: ${{ inputs.git_ref }}
-
-
-      - name: Determine the minimum and maximum Terraform versions
-        id: v
-        uses: clowdhaus/terraform-min-max@9a19164e967d57d2b8f1e5b0854f39bc73265d8b # v1.3.1
-        with:
-          directory: ${{ inputs.working_directory }}
-
-
   terraform-plan:
 
     name: Create a Terraform execution plan
-
-    needs:
-      - terraform-version
 
     runs-on: ubuntu-latest
 
@@ -174,10 +144,15 @@ jobs:
           echo "PLAN_FILENAME=plan-${{ github.run_id }}_${{ steps.output-hashes.outputs.CHECKOUT_SHA }}_${{ steps.output-hashes.outputs.WORKDIR_SHORT_SHA }}.tfplan" >> "$GITHUB_OUTPUT"
 
 
+      - name: Extract Terraform version
+        id: v
+        run: echo "TERRAFORM_VERSION=$(grep required_version *.tf | sed -E 's/[^"]+"([^"]+)"+/\1/')" >> "$GITHUB_OUTPUT"
+
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
-          terraform_version: "${{ needs.terraform-version.outputs.max }}"
+          terraform_version: ${{ steps.v.outputs.TERRAFORM_VERSION }}
 
 
       - name: Create Terraform provider plugins cache directory

--- a/.github/workflows/reusable-terraform-plan-apply.yml
+++ b/.github/workflows/reusable-terraform-plan-apply.yml
@@ -108,6 +108,7 @@ jobs:
 
     outputs:
       plan_filename: ${{ steps.output-plan-filename.outputs.PLAN_FILENAME }}
+      terraform_version: ${{ steps.v.outputs.TERRAFORM_VERSION }}
 
     steps:
 
@@ -235,7 +236,6 @@ jobs:
   terraform-apply:
 
     needs:
-      - terraform-version
       - terraform-plan
 
     if: ${{ inputs.apply }}
@@ -304,7 +304,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
-          terraform_version: "${{ needs.terraform-version.outputs.max }}"
+          terraform_version: "${{ needs.terraform-plan.outputs.terraform_version }}"
 
 
       - name: Create Terraform provider plugins cache directory


### PR DESCRIPTION

<!--- Using the headings below is optional, do whatever makes sense to you. -->

## Description
<!--- Describe your changes in detail. -->
- Replaces separate action and job with inline version extraction
- Uses grep and sed to parse version from .tf files
- Sets extracted version as output for use in setup-terraform step
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here using the syntax: 'Closes #123' -->

Job costs 1 run minute. It's inefficient.

<!-- markdownlint-disable-file MD041 -->
