### PR TITLE
fix: disable shell interpolation in heredoc

### DIFF
--- a/.github/workflows/reusable-terraform-plan-apply.yml
+++ b/.github/workflows/reusable-terraform-plan-apply.yml
@@ -192,16 +192,16 @@ jobs:
       - if: github.event_name == 'pull_request'
         name: Create Terraform plan summary file
         run: |
-          cat << EOF > plan.md
+          cat << 'EOF' > plan.md
           ## Terraform execution
 
-          Running Terraform in \`${{ inputs.working_directory }}\`.
+          Running Terraform in `${{ inputs.working_directory }}`.
 
           <details><summary>Show plan</summary>
 
-          \`\`\`terraform
+          ```terraform
           ${{ steps.plan.outputs.stdout }}
-          \`\`\`
+          ```
 
           </details>
           EOF
@@ -229,11 +229,11 @@ jobs:
 
       - name: Write plan summary
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
           # Plan
-          \`\`\`tfplan
+          ```tfplan
           ${{ steps.plan.outputs.stdout }}
-          \`\`\`
+          ```
           EOF
 
 
@@ -367,7 +367,7 @@ jobs:
 
       - name: Write apply summary
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
           # Apply
           \`\`\`tfplan
           ${{ steps.apply.outputs.stdout }}


### PR DESCRIPTION
This ensures that the shell won't attempt to interpolate strings like ${hcl_var} in the Terraform plan output which leads to shell (and thus workflow) errors like `bad substitution`.