### PR TITLE
fix: add comment for each stack processed

### DIFF
--- a/.github/workflows/reusable-terraform-plan-apply.yml
+++ b/.github/workflows/reusable-terraform-plan-apply.yml
@@ -194,6 +194,7 @@ jobs:
         run: |
           cat << 'EOF' > plan.md
           ## Terraform execution
+          <!--reusable-terraform-plan-apply:${{inputs.working_directory}}-->
 
           Running Terraform in `${{ inputs.working_directory }}`.
 
@@ -214,7 +215,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: '<details><summary>Show plan</summary>'
+          body-includes: '<!--reusable-terraform-plan-apply:${{inputs.working_directory}}-->'
 
 
       - if: github.event_name == 'pull_request'


### PR DESCRIPTION
If multiple stacks are processed in the same run, the comment will be overwritten by the plan results of the final stack. This fixes that issue and creates separate comments per stack.